### PR TITLE
refactor: lift state-machine engine into owned instance (#9)

### DIFF
--- a/SlimStateMachine.Tests/Entities.cs
+++ b/SlimStateMachine.Tests/Entities.cs
@@ -46,3 +46,23 @@ public class Order
     public OrderStatus Status { get; set; }
     public string? CustomerName { get; set; }
 }
+
+/// <summary>
+/// Dedicated entity/enum pair used only by StateMachineDefinitionTests' static-façade tests,
+/// so they never share the static StateMachine&lt;,&gt; cache with any other test class under
+/// class-level parallelization.
+/// </summary>
+public enum TicketStatus
+{
+    Open,
+    InProgress,
+    Resolved,
+    Closed
+}
+
+public class Ticket
+{
+    public int Id { get; set; }
+    public TicketStatus Status { get; set; }
+    public bool IsApproved { get; set; }
+}

--- a/SlimStateMachine.Tests/InvoiceStateMachineTests.cs
+++ b/SlimStateMachine.Tests/InvoiceStateMachineTests.cs
@@ -8,7 +8,7 @@
         public void TestInitialize()
         {
             // Use internal method for test cleanup
-            StateMachine<Invoice, InvoiceStatus>.ClearConfiguration_TestOnly();
+            StateMachine<Invoice, InvoiceStatus>.Reset();
         }
 
         private static void ConfigureInvoiceStateMachine(bool includeConditions = true)
@@ -170,7 +170,7 @@
             var invoice = new Invoice { Id = 1, Status = InvoiceStatus.Sent, TotalAmount = 100, AmountPaid = 100 };
             string? reason = null;
             // Reconfigure slightly to capture post action effect
-            StateMachine<Invoice, InvoiceStatus>.ClearConfiguration_TestOnly();
+            StateMachine<Invoice, InvoiceStatus>.Reset();
             StateMachine<Invoice, InvoiceStatus>.Configure(inv => inv.Status, b => {
                 b.SetInitialState(InvoiceStatus.Draft);
                 b.AllowTransition(InvoiceStatus.Sent, InvoiceStatus.Paid, inv => inv.RemainingAmount <= 0, null, _ => reason = "Paid");
@@ -950,8 +950,8 @@
         public void TestCleanup()
         {
             // Clean up Order state machine after tests that use it
-            StateMachine<Order, OrderStatus>.ClearConfiguration_TestOnly();
-            StateMachine<ReadOnlyInvoice, InvoiceStatus>.ClearConfiguration_TestOnly();
+            StateMachine<Order, OrderStatus>.Reset();
+            StateMachine<ReadOnlyInvoice, InvoiceStatus>.Reset();
         }
 
         #endregion

--- a/SlimStateMachine.Tests/StateMachineDefinitionTests.cs
+++ b/SlimStateMachine.Tests/StateMachineDefinitionTests.cs
@@ -1,0 +1,499 @@
+namespace SlimStateMachine.Tests
+{
+    /// <summary>
+    /// Tests for the instance-based <see cref="StateMachineDefinition{TEntity, TEnum}"/> surface
+    /// and the static <see cref="StateMachine{TEntity, TEnum}"/> façade-management API
+    /// (Use/Reset/Current and forwarding OnTransition) introduced by issue #9.
+    ///
+    /// Parallel-safety: the assembly runs test classes in parallel (see MSTestSettings.cs).
+    /// Pure instance tests share no static state, so they may safely use Invoice/InvoiceStatus.
+    /// Tests that touch the static façade use the dedicated Ticket/TicketStatus pair, which no
+    /// other test class references, so they never collide with InvoiceStateMachineTests on the
+    /// shared static StateMachine&lt;Invoice, InvoiceStatus&gt; cache.
+    /// </summary>
+    [TestClass]
+    public class StateMachineDefinitionTests
+    {
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            StateMachine<Ticket, TicketStatus>.Reset();
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            StateMachine<Ticket, TicketStatus>.Reset();
+        }
+
+        // --- Instance builders (no static state) ---
+
+        private static StateMachineDefinition<Invoice, InvoiceStatus> BuildSimpleInvoiceDefinition()
+        {
+            return StateMachineDefinition<Invoice, InvoiceStatus>.Build(
+                invoice => invoice.Status,
+                builder =>
+                {
+                    builder.SetInitialState(InvoiceStatus.Draft);
+                    builder.AllowTransition(InvoiceStatus.Draft, InvoiceStatus.Sent);
+                    builder.AllowTransition(
+                        InvoiceStatus.Sent,
+                        InvoiceStatus.Paid,
+                        preCondition: inv => inv.RemainingAmount <= 0,
+                        preConditionExpression: "Remaining == 0");
+                    builder.AllowTransition(
+                        InvoiceStatus.Draft,
+                        InvoiceStatus.Cancelled,
+                        postAction: inv => inv.CancellationReason = "Cancelled from Draft");
+                });
+        }
+
+        // --- Façade builder (dedicated Ticket type) ---
+
+        private static StateMachineDefinition<Ticket, TicketStatus> BuildSimpleTicketDefinition()
+        {
+            return StateMachineDefinition<Ticket, TicketStatus>.Build(
+                ticket => ticket.Status,
+                builder =>
+                {
+                    builder.SetInitialState(TicketStatus.Open);
+                    builder.AllowTransition(TicketStatus.Open, TicketStatus.InProgress);
+                    builder.AllowTransition(TicketStatus.InProgress, TicketStatus.Resolved);
+                });
+        }
+
+        #region Isolation / parallel-safety
+
+        [TestMethod]
+        public void TwoDefinitions_SameTypeArgs_DifferentTransitions_BehaveIndependently()
+        {
+            // Definition A: Draft -> Sent allowed, Draft -> Cancelled NOT defined.
+            var defA = StateMachineDefinition<Invoice, InvoiceStatus>.Build(
+                invoice => invoice.Status,
+                builder =>
+                {
+                    builder.SetInitialState(InvoiceStatus.Draft);
+                    builder.AllowTransition(InvoiceStatus.Draft, InvoiceStatus.Sent);
+                });
+
+            // Definition B: Draft -> Cancelled allowed, Draft -> Sent NOT defined.
+            var defB = StateMachineDefinition<Invoice, InvoiceStatus>.Build(
+                invoice => invoice.Status,
+                builder =>
+                {
+                    builder.SetInitialState(InvoiceStatus.Draft);
+                    builder.AllowTransition(InvoiceStatus.Draft, InvoiceStatus.Cancelled);
+                });
+
+            var invoiceForA = new Invoice { Id = 1, Status = InvoiceStatus.Draft };
+            var invoiceForB = new Invoice { Id = 2, Status = InvoiceStatus.Draft };
+
+            // A allows Sent but rejects Cancelled
+            Assert.IsTrue(defA.CanTransition(invoiceForA, InvoiceStatus.Sent));
+            Assert.IsFalse(defA.CanTransition(invoiceForA, InvoiceStatus.Cancelled));
+
+            // B allows Cancelled but rejects Sent (proving no shared static state)
+            Assert.IsTrue(defB.CanTransition(invoiceForB, InvoiceStatus.Cancelled));
+            Assert.IsFalse(defB.CanTransition(invoiceForB, InvoiceStatus.Sent));
+
+            // And the actual transitions land independently
+            Assert.IsTrue(defA.TryTransition(invoiceForA, InvoiceStatus.Sent));
+            Assert.AreEqual(InvoiceStatus.Sent, invoiceForA.Status);
+
+            Assert.IsTrue(defB.TryTransition(invoiceForB, InvoiceStatus.Cancelled));
+            Assert.AreEqual(InvoiceStatus.Cancelled, invoiceForB.Status);
+        }
+
+        #endregion
+
+        #region Instance transition behavior
+
+        [TestMethod]
+        public void Instance_TryTransition_HappyPath_UpdatesState()
+        {
+            var def = BuildSimpleInvoiceDefinition();
+            var invoice = new Invoice { Id = 1, Status = InvoiceStatus.Draft };
+
+            Assert.IsTrue(def.TryTransition(invoice, InvoiceStatus.Sent));
+            Assert.AreEqual(InvoiceStatus.Sent, invoice.Status);
+        }
+
+        [TestMethod]
+        public void Instance_TryTransition_PreConditionGating_BlocksWhenNotMet()
+        {
+            var def = BuildSimpleInvoiceDefinition();
+            // Sent -> Paid requires RemainingAmount <= 0
+            var invoice = new Invoice { Id = 1, Status = InvoiceStatus.Sent, TotalAmount = 100, AmountPaid = 50 };
+
+            Assert.IsFalse(def.CanTransition(invoice, InvoiceStatus.Paid));
+            Assert.IsFalse(def.TryTransition(invoice, InvoiceStatus.Paid));
+            Assert.AreEqual(InvoiceStatus.Sent, invoice.Status);
+
+            // Once condition is met, it succeeds
+            invoice.AmountPaid = 100;
+            Assert.IsTrue(def.CanTransition(invoice, InvoiceStatus.Paid));
+            Assert.IsTrue(def.TryTransition(invoice, InvoiceStatus.Paid));
+            Assert.AreEqual(InvoiceStatus.Paid, invoice.Status);
+        }
+
+        [TestMethod]
+        public void Instance_ForceTransition_BypassesPreCondition()
+        {
+            var def = BuildSimpleInvoiceDefinition();
+            // Sent -> Paid requires RemainingAmount <= 0; this invoice fails that condition
+            var invoice = new Invoice { Id = 1, Status = InvoiceStatus.Sent, TotalAmount = 100, AmountPaid = 50 };
+
+            Assert.IsFalse(def.TryTransition(invoice, InvoiceStatus.Paid)); // gated
+            Assert.IsTrue(def.ForceTransition(invoice, InvoiceStatus.Paid)); // bypassed
+            Assert.AreEqual(InvoiceStatus.Paid, invoice.Status);
+        }
+
+        [TestMethod]
+        public void Instance_Queries_ReflectConfiguration()
+        {
+            var def = BuildSimpleInvoiceDefinition();
+
+            Assert.AreEqual(InvoiceStatus.Draft, def.InitialState);
+
+            CollectionAssert.AreEquivalent(
+                new[] { InvoiceStatus.Sent, InvoiceStatus.Cancelled },
+                def.GetDefinedTransitions(InvoiceStatus.Draft).ToList());
+
+            Assert.IsTrue(def.IsFinalState(InvoiceStatus.Paid));
+            Assert.IsFalse(def.IsFinalState(InvoiceStatus.Draft));
+
+            var paidInvoice = new Invoice { Id = 1, Status = InvoiceStatus.Paid };
+            Assert.IsTrue(def.IsInFinalState(paidInvoice));
+
+            CollectionAssert.AreEqual(
+                new[] { InvoiceStatus.Draft, InvoiceStatus.Sent, InvoiceStatus.Paid, InvoiceStatus.Cancelled },
+                def.GetAllStates());
+
+            var all = def.GetAllTransitions();
+            CollectionAssert.AreEquivalent(
+                new[] { InvoiceStatus.Sent, InvoiceStatus.Cancelled },
+                all[InvoiceStatus.Draft]);
+        }
+
+        #endregion
+
+        #region Per-instance OnTransition
+
+        [TestMethod]
+        public void Instance_OnTransition_DoesNotFireForOtherInstance()
+        {
+            var defA = BuildSimpleInvoiceDefinition();
+            var defB = BuildSimpleInvoiceDefinition();
+
+            int aFired = 0;
+            int bFired = 0;
+            defA.OnTransition += _ => aFired++;
+            defB.OnTransition += _ => bFired++;
+
+            var invoice = new Invoice { Id = 1, Status = InvoiceStatus.Draft };
+            Assert.IsTrue(defA.TryTransition(invoice, InvoiceStatus.Sent));
+
+            Assert.AreEqual(1, aFired);
+            Assert.AreEqual(0, bFired); // B's handler must not fire for A's transition
+        }
+
+        [TestMethod]
+        public void Instance_OnTransition_ContextFieldsAreCorrect()
+        {
+            var def = BuildSimpleInvoiceDefinition();
+
+            TransitionContext<Invoice, InvoiceStatus>? captured = null;
+            def.OnTransition += ctx => captured = ctx;
+
+            var invoice = new Invoice { Id = 1, Status = InvoiceStatus.Draft };
+            var metadata = new Dictionary<string, object> { ["UserId"] = 7 };
+
+            Assert.IsTrue(def.TryTransition(invoice, InvoiceStatus.Sent, "instance reason", metadata));
+
+            Assert.IsNotNull(captured);
+            Assert.AreSame(invoice, captured!.Entity);
+            Assert.AreEqual(InvoiceStatus.Draft, captured.FromState);
+            Assert.AreEqual(InvoiceStatus.Sent, captured.ToState);
+            Assert.AreEqual("instance reason", captured.Reason);
+            Assert.AreEqual(7, captured.Metadata!["UserId"]);
+            Assert.IsFalse(captured.WasForced);
+        }
+
+        [TestMethod]
+        public void Instance_OnTransition_WasForced_TrueForForceTransition()
+        {
+            var def = BuildSimpleInvoiceDefinition();
+
+            TransitionContext<Invoice, InvoiceStatus>? captured = null;
+            def.OnTransition += ctx => captured = ctx;
+
+            // Sent -> Paid condition fails, so force it
+            var invoice = new Invoice { Id = 1, Status = InvoiceStatus.Sent, TotalAmount = 100, AmountPaid = 50 };
+            Assert.IsTrue(def.ForceTransition(invoice, InvoiceStatus.Paid, "admin"));
+
+            Assert.IsNotNull(captured);
+            Assert.IsTrue(captured!.WasForced);
+            Assert.AreEqual("admin", captured.Reason);
+        }
+
+        #endregion
+
+        #region Instance carries no global state
+
+        [TestMethod]
+        public void Build_DoesNotMakeStaticCurrentResolve()
+        {
+            // Clean slate already ensured by TestInitialize's Reset of the Ticket façade.
+            _ = BuildSimpleTicketDefinition();
+
+            // Building an instance must NOT register it with the static façade.
+            Assert.ThrowsException<InvalidOperationException>(() =>
+                _ = StateMachine<Ticket, TicketStatus>.Current);
+
+            Assert.ThrowsException<InvalidOperationException>(() =>
+                _ = StateMachine<Ticket, TicketStatus>.InitialState);
+        }
+
+        #endregion
+
+        #region Use + façade delegation
+
+        [TestMethod]
+        public void Use_ThenFacade_DelegatesToInstance()
+        {
+            var def = BuildSimpleTicketDefinition();
+            StateMachine<Ticket, TicketStatus>.Use(def);
+
+            Assert.AreSame(def, StateMachine<Ticket, TicketStatus>.Current);
+            Assert.AreEqual(TicketStatus.Open, StateMachine<Ticket, TicketStatus>.InitialState);
+
+            var ticket = new Ticket { Id = 1, Status = TicketStatus.Open };
+            Assert.IsTrue(StateMachine<Ticket, TicketStatus>.TryTransition(ticket, TicketStatus.InProgress));
+            Assert.AreEqual(TicketStatus.InProgress, ticket.Status);
+
+            CollectionAssert.AreEquivalent(
+                new[] { TicketStatus.InProgress },
+                StateMachine<Ticket, TicketStatus>.GetDefinedTransitions(TicketStatus.Open).ToList());
+        }
+
+        [TestMethod]
+        public void Use_Twice_ThrowsInvalidOperationException()
+        {
+            StateMachine<Ticket, TicketStatus>.Use(BuildSimpleTicketDefinition());
+
+            Assert.ThrowsException<InvalidOperationException>(() =>
+                StateMachine<Ticket, TicketStatus>.Use(BuildSimpleTicketDefinition()));
+        }
+
+        [TestMethod]
+        public void Configure_ThenUse_ThrowsInvalidOperationException()
+        {
+            StateMachine<Ticket, TicketStatus>.Configure(
+                ticket => ticket.Status,
+                builder => builder.SetInitialState(TicketStatus.Open));
+
+            Assert.ThrowsException<InvalidOperationException>(() =>
+                StateMachine<Ticket, TicketStatus>.Use(BuildSimpleTicketDefinition()));
+        }
+
+        [TestMethod]
+        public void Use_AfterReset_SucceedsAgain()
+        {
+            StateMachine<Ticket, TicketStatus>.Use(BuildSimpleTicketDefinition());
+            Assert.IsTrue(StateMachine<Ticket, TicketStatus>.Reset());
+
+            var second = BuildSimpleTicketDefinition();
+            StateMachine<Ticket, TicketStatus>.Use(second); // should not throw
+            Assert.AreSame(second, StateMachine<Ticket, TicketStatus>.Current);
+        }
+
+        #endregion
+
+        #region Reset return value
+
+        [TestMethod]
+        public void Reset_ReturnsFalse_WhenNothingConfigured()
+        {
+            // TestInitialize already reset; a fresh reset should report nothing cleared.
+            Assert.IsFalse(StateMachine<Ticket, TicketStatus>.Reset());
+        }
+
+        [TestMethod]
+        public void Reset_ReturnsTrue_AfterConfigure_AndCurrentThrowsAfterward()
+        {
+            StateMachine<Ticket, TicketStatus>.Configure(
+                ticket => ticket.Status,
+                builder => builder.SetInitialState(TicketStatus.Open));
+
+            Assert.IsTrue(StateMachine<Ticket, TicketStatus>.Reset());
+            Assert.ThrowsException<InvalidOperationException>(() =>
+                _ = StateMachine<Ticket, TicketStatus>.Current);
+        }
+
+        [TestMethod]
+        public void Reset_ReturnsTrue_AfterUse()
+        {
+            StateMachine<Ticket, TicketStatus>.Use(BuildSimpleTicketDefinition());
+            Assert.IsTrue(StateMachine<Ticket, TicketStatus>.Reset());
+        }
+
+        [TestMethod]
+        public void Reset_IsIdempotent()
+        {
+            StateMachine<Ticket, TicketStatus>.Use(BuildSimpleTicketDefinition());
+            Assert.IsTrue(StateMachine<Ticket, TicketStatus>.Reset());
+            Assert.IsFalse(StateMachine<Ticket, TicketStatus>.Reset()); // second time clears nothing
+        }
+
+        #endregion
+
+        #region Current throws when unconfigured
+
+        [TestMethod]
+        public void Current_Unconfigured_ThrowsWithNotConfiguredMessage()
+        {
+            try
+            {
+                _ = StateMachine<Ticket, TicketStatus>.Current;
+                Assert.Fail("Expected InvalidOperationException");
+            }
+            catch (InvalidOperationException ex)
+            {
+                Assert.IsTrue(ex.Message.Contains("not been configured"), $"Unexpected message: {ex.Message}");
+            }
+        }
+
+        #endregion
+
+        #region Static OnTransition forwarding
+
+        [TestMethod]
+        public void StaticOnTransition_SubscribeBeforeConfigure_Throws()
+        {
+            // Subscribe forwards to Current, which throws when unconfigured.
+            Assert.ThrowsException<InvalidOperationException>(() =>
+                StateMachine<Ticket, TicketStatus>.OnTransition += _ => { });
+        }
+
+        [TestMethod]
+        public void StaticOnTransition_FiresAfterConfigure()
+        {
+            StateMachine<Ticket, TicketStatus>.Configure(
+                ticket => ticket.Status,
+                builder =>
+                {
+                    builder.SetInitialState(TicketStatus.Open);
+                    builder.AllowTransition(TicketStatus.Open, TicketStatus.InProgress);
+                });
+
+            TransitionContext<Ticket, TicketStatus>? captured = null;
+            StateMachine<Ticket, TicketStatus>.OnTransition += ctx => captured = ctx;
+
+            var ticket = new Ticket { Id = 1, Status = TicketStatus.Open };
+            StateMachine<Ticket, TicketStatus>.TryTransition(ticket, TicketStatus.InProgress);
+
+            Assert.IsNotNull(captured);
+            Assert.AreEqual(TicketStatus.InProgress, captured!.ToState);
+        }
+
+        [TestMethod]
+        public void StaticOnTransition_HandlerDiesWithInstanceAfterReset()
+        {
+            // Configure and subscribe a handler bound to the first instance.
+            StateMachine<Ticket, TicketStatus>.Configure(
+                ticket => ticket.Status,
+                builder =>
+                {
+                    builder.SetInitialState(TicketStatus.Open);
+                    builder.AllowTransition(TicketStatus.Open, TicketStatus.InProgress);
+                });
+
+            int oldHandlerFired = 0;
+            StateMachine<Ticket, TicketStatus>.OnTransition += _ => oldHandlerFired++;
+
+            // Reset clears the instance; the handler lived on that instance and should die with it.
+            Assert.IsTrue(StateMachine<Ticket, TicketStatus>.Reset());
+
+            // Reconfigure with a brand-new instance and transition.
+            StateMachine<Ticket, TicketStatus>.Configure(
+                ticket => ticket.Status,
+                builder =>
+                {
+                    builder.SetInitialState(TicketStatus.Open);
+                    builder.AllowTransition(TicketStatus.Open, TicketStatus.InProgress);
+                });
+
+            var ticket = new Ticket { Id = 1, Status = TicketStatus.Open };
+            StateMachine<Ticket, TicketStatus>.TryTransition(ticket, TicketStatus.InProgress);
+
+            Assert.AreEqual(0, oldHandlerFired); // old handler must not fire after Reset
+        }
+
+        #endregion
+
+        #region Build argument null-checks
+
+        [TestMethod]
+        public void Build_NullAccessor_ThrowsArgumentNullException()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() =>
+                StateMachineDefinition<Invoice, InvoiceStatus>.Build(
+                    null!,
+                    builder => builder.SetInitialState(InvoiceStatus.Draft)));
+        }
+
+        [TestMethod]
+        public void Build_NullConfigureAction_ThrowsArgumentNullException()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() =>
+                StateMachineDefinition<Invoice, InvoiceStatus>.Build(
+                    invoice => invoice.Status,
+                    null!));
+        }
+
+        #endregion
+
+        #region Instance diagram generation
+
+        [TestMethod]
+        public void Instance_GenerateMermaidGraph_ProducesExpectedMarkers()
+        {
+            var def = BuildSimpleInvoiceDefinition();
+            var graph = def.GenerateMermaidGraph();
+
+            Assert.IsTrue(graph.StartsWith("graph TD"));
+            Assert.IsTrue(graph.Contains("Start((⚪)) --> Draft"));
+            Assert.IsTrue(graph.Contains("Draft --> Sent"));
+        }
+
+        [TestMethod]
+        public void Instance_GenerateD2Graph_ProducesExpectedMarkers()
+        {
+            var def = BuildSimpleInvoiceDefinition();
+            var graph = def.GenerateD2Graph();
+
+            Assert.IsTrue(graph.Contains("# State Machine: Invoice - InvoiceStatus"));
+            Assert.IsTrue(graph.Contains("Start -> Draft"));
+        }
+
+        [TestMethod]
+        public void Instance_GenerateDiagram_D2_ProducesExpectedMarkers()
+        {
+            var def = BuildSimpleInvoiceDefinition();
+            var diagram = def.GenerateDiagram(StateMachine<Invoice, InvoiceStatus>.DiagramType.D2);
+
+            Assert.IsTrue(diagram.Contains("# State Machine: Invoice - InvoiceStatus"));
+        }
+
+        [TestMethod]
+        public void Instance_GenerateDiagram_Mermaid_ProducesExpectedMarkers()
+        {
+            var def = BuildSimpleInvoiceDefinition();
+            var diagram = def.GenerateDiagram(StateMachine<Invoice, InvoiceStatus>.DiagramType.Mermaid);
+
+            Assert.IsTrue(diagram.StartsWith("graph TD"));
+        }
+
+        #endregion
+    }
+}

--- a/SlimStateMachine/StateMachine.D2.cs
+++ b/SlimStateMachine/StateMachine.D2.cs
@@ -1,5 +1,3 @@
-﻿using System.Text;
-
 namespace SlimStateMachine;
 
 public static partial class StateMachine<TEntity, TEnum>
@@ -10,10 +8,7 @@ public static partial class StateMachine<TEntity, TEnum>
     /// </summary>
     /// <param name="includeStyles">When true, includes styling for the diagram. Default is true.</param>
     /// <returns>A string suitable for rendering with D2.</returns>
-    public static string GenerateD2Graph(bool includeStyles = true)
-    {
-        return GenerateD2Graph(entity: default, currentState: null, includeStyles);
-    }
+    public static string GenerateD2Graph(bool includeStyles = true) => Current.GenerateD2Graph(includeStyles);
 
     /// <summary>
     /// Generates a D2 diagram definition string representing the configured state machine
@@ -22,10 +17,7 @@ public static partial class StateMachine<TEntity, TEnum>
     /// <param name="entity">The entity instance whose current state should be highlighted.</param>
     /// <param name="includeStyles">When true, includes styling for the diagram. Default is true.</param>
     /// <returns>A string suitable for rendering with D2.</returns>
-    public static string GenerateD2Graph(TEntity entity, bool includeStyles = true)
-    {
-        return GenerateD2Graph(entity: entity, null, includeStyles);
-    }
+    public static string GenerateD2Graph(TEntity entity, bool includeStyles = true) => Current.GenerateD2Graph(entity, includeStyles);
 
     /// <summary>
     /// Generates a D2 diagram definition string representing the configured state machine
@@ -34,97 +26,7 @@ public static partial class StateMachine<TEntity, TEnum>
     /// <param name="currentState">The state to highlight.</param>
     /// <param name="includeStyles">When true, includes styling for the diagram. Default is true.</param>
     /// <returns>A string suitable for rendering with D2.</returns>
-    public static string GenerateD2Graph(TEnum currentState, bool includeStyles = true)
-    {
-        return GenerateD2Graph(entity: default, currentState, includeStyles);
-    }
-
-    private static string GenerateD2Graph(TEntity? entity, TEnum? currentState, bool includeStyles)
-    {
-        var config = GetConfiguration();
-        var sb = new StringBuilder();
-
-        // If entity is provided but currentState is default, get the current state from the entity
-        if (entity is not null && currentState is null)
-            currentState = config.GetCurrentState(entity);
-
-        // Track if we're highlighting a specific state
-        var isHighlightingState = currentState is not null;
-
-        // Add title and direction
-        sb.AppendLine($"# State Machine: {typeof(TEntity).Name} - {typeof(TEnum).Name}");
-        if (isHighlightingState)
-            sb.AppendLine($"# Current State: {currentState}");
-        sb.AppendLine("direction: down");
-        sb.AppendLine();
-
-        // Add styling if requested
-        if (includeStyles)
-        {
-            sb.AppendLine("# Styles");
-            sb.AppendLine("style {");
-            sb.AppendLine("  fill: honeydew");
-            sb.AppendLine("  stroke: limegreen");
-            sb.AppendLine("  stroke-width: 2");
-            sb.AppendLine("  font-size: 14");
-            sb.AppendLine("  shadow: true");
-            sb.AppendLine("}");
-            sb.AppendLine();
-
-            // Style for the Start node
-            sb.AppendLine("Start: {");
-            sb.AppendLine("  shape: circle");
-            sb.AppendLine("  style.fill: lightgreen");
-            sb.AppendLine("  style.stroke: green");
-            sb.AppendLine("  width: 40");
-            sb.AppendLine("  height: 40");
-            sb.AppendLine("}");
-            sb.AppendLine();
-
-            // Add highlighting style for current state if specified
-            if (isHighlightingState)
-            {
-                sb.AppendLine($"{currentState}: {{");
-                sb.AppendLine("  style.fill: lightyellow");
-                sb.AppendLine("  style.stroke: orange");
-                sb.AppendLine("  style.stroke-width: 3");
-                sb.AppendLine("  style.shadow: true");
-                sb.AppendLine("}");
-                sb.AppendLine();
-            }
-        }
-
-        // Add initial state marker
-        sb.AppendLine($"Start -> {config.InitialState}");
-        sb.AppendLine();
-
-        // Add all defined transitions
-        var allTransitions = config.Transitions.Values.SelectMany(list => list).ToArray();
-
-        if (!allTransitions.Any())
-        {
-            // If only initial state defined, ensure it shows up
-            sb.AppendLine($"{config.InitialState}");
-        }
-        else
-        {
-            sb.AppendLine("# Transitions");
-            foreach (var transition in allTransitions)
-            {
-                if (!string.IsNullOrWhiteSpace(transition.PreConditionExpression))
-                {
-                    // D2 uses a different label syntax than Mermaid
-                    sb.AppendLine($"{transition.FromState} -> {transition.ToState}: {transition.PreConditionExpression}");
-                }
-                else
-                {
-                    sb.AppendLine($"{transition.FromState} -> {transition.ToState}");
-                }
-            }
-        }
-
-        return sb.ToString();
-    }
+    public static string GenerateD2Graph(TEnum currentState, bool includeStyles = true) => Current.GenerateD2Graph(currentState, includeStyles);
 
     /// <summary>
     /// Enum to specify the diagram type to generate.
@@ -141,15 +43,7 @@ public static partial class StateMachine<TEntity, TEnum>
     /// </summary>
     /// <param name="diagramType">The type of diagram to generate.</param>
     /// <returns>A string suitable for rendering with the specified diagramming tool.</returns>
-    public static string GenerateDiagram(DiagramType diagramType)
-    {
-        return diagramType switch
-        {
-            DiagramType.Mermaid => GenerateMermaidGraph(),
-            DiagramType.D2 => GenerateD2Graph(),
-            _ => throw new ArgumentException($"Unsupported diagram type: {diagramType}")
-        };
-    }
+    public static string GenerateDiagram(DiagramType diagramType) => Current.GenerateDiagram(diagramType);
 
     /// <summary>
     /// Generates a diagram definition string representing the configured state machine
@@ -158,15 +52,7 @@ public static partial class StateMachine<TEntity, TEnum>
     /// <param name="diagramType">The type of diagram to generate.</param>
     /// <param name="entity">The entity whose current state should be highlighted.</param>
     /// <returns>A string suitable for rendering with the specified diagramming tool.</returns>
-    public static string GenerateDiagram(DiagramType diagramType, TEntity entity)
-    {
-        return diagramType switch
-        {
-            DiagramType.Mermaid => GenerateMermaidGraph(entity),
-            DiagramType.D2 => GenerateD2Graph(entity),
-            _ => throw new ArgumentException($"Unsupported diagram type: {diagramType}")
-        };
-    }
+    public static string GenerateDiagram(DiagramType diagramType, TEntity entity) => Current.GenerateDiagram(diagramType, entity);
 
     /// <summary>
     /// Generates a diagram definition string representing the configured state machine
@@ -175,13 +61,5 @@ public static partial class StateMachine<TEntity, TEnum>
     /// <param name="diagramType">The type of diagram to generate.</param>
     /// <param name="currentState">The state to highlight.</param>
     /// <returns>A string suitable for rendering with the specified diagramming tool.</returns>
-    public static string GenerateDiagram(DiagramType diagramType, TEnum currentState)
-    {
-        return diagramType switch
-        {
-            DiagramType.Mermaid => GenerateMermaidGraph(currentState),
-            DiagramType.D2 => GenerateD2Graph(currentState),
-            _ => throw new ArgumentException($"Unsupported diagram type: {diagramType}")
-        };
-    }
+    public static string GenerateDiagram(DiagramType diagramType, TEnum currentState) => Current.GenerateDiagram(diagramType, currentState);
 }

--- a/SlimStateMachine/StateMachine.cs
+++ b/SlimStateMachine/StateMachine.cs
@@ -16,7 +16,7 @@ public static partial class StateMachine<TEntity, TEnum>
     where TEnum : struct, Enum // Ensure TEnum is an enum
 {
     // ReSharper disable StaticMemberInGenericType
-    private static StateMachineDefinition<TEntity, TEnum>? _current;
+    private static volatile StateMachineDefinition<TEntity, TEnum>? _current;
 
 #if NET9_0_OR_GREATER
     private static readonly Lock _configureLock = new();
@@ -32,7 +32,13 @@ public static partial class StateMachine<TEntity, TEnum>
     public static event Action<TransitionContext<TEntity, TEnum>>? OnTransition
     {
         add => Current.OnTransition += value;
-        remove => Current.OnTransition -= value;
+        remove
+        {
+            // Tolerate unsubscribe after Reset() (e.g. during disposal): nothing to remove.
+            var current = _current;
+            if (current is not null)
+                current.OnTransition -= value;
+        }
     }
 
     /// <summary>

--- a/SlimStateMachine/StateMachine.cs
+++ b/SlimStateMachine/StateMachine.cs
@@ -1,7 +1,5 @@
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
-using System.Text;
-using SlimStateMachine.Internal;
 
 [assembly: InternalsVisibleTo("SlimStateMachine.Tests")]
 
@@ -9,27 +7,48 @@ namespace SlimStateMachine;
 
 /// <summary>
 /// Provides static methods for defining and interacting with state machines
-/// associated with an entity type and its status enum property.
+/// associated with an entity type and its status enum property. This is a thin,
+/// resettable façade over a single registered <see cref="StateMachineDefinition{TEntity, TEnum}"/> instance.
 /// </summary>
 /// <typeparam name="TEntity">The type of the entity being managed.</typeparam>
 /// <typeparam name="TEnum">The enum type representing the state (must be struct, Enum).</typeparam>
 public static partial class StateMachine<TEntity, TEnum>
     where TEnum : struct, Enum // Ensure TEnum is an enum
 {
-    private static StateMachineConfiguration<TEntity, TEnum>? _config;
-
     // ReSharper disable StaticMemberInGenericType
+    private static StateMachineDefinition<TEntity, TEnum>? _current;
+
 #if NET9_0_OR_GREATER
     private static readonly Lock _configureLock = new();
 #else
     private static readonly object _configureLock = new();
 #endif
+    // ReSharper restore StaticMemberInGenericType
 
     /// <summary>
-    /// Event raised after a successful state transition.
+    /// Event raised after a successful state transition. Forwards subscriptions to the
+    /// registered instance, so the state machine must be configured first.
     /// </summary>
-    public static event Action<TransitionContext<TEntity, TEnum>>? OnTransition;
-    // ReSharper restore StaticMemberInGenericType
+    public static event Action<TransitionContext<TEntity, TEnum>>? OnTransition
+    {
+        add => Current.OnTransition += value;
+        remove => Current.OnTransition -= value;
+    }
+
+    /// <summary>
+    /// Gets the registered state machine instance.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown if the state machine is not configured.</exception>
+    public static StateMachineDefinition<TEntity, TEnum> Current
+    {
+        get
+        {
+            if (_current is null)
+                throw new InvalidOperationException($"State machine for {typeof(TEntity).Name} with status {typeof(TEnum).Name} has not been configured. Call Configure() first.");
+
+            return _current;
+        }
+    }
 
     /// <summary>
     /// Configures the state machine for the given TEntity and TEnum types.
@@ -48,15 +67,13 @@ public static partial class StateMachine<TEntity, TEnum>
         if (configureAction == null) throw new ArgumentNullException(nameof(configureAction));
 
         // Double-checked locking pattern for thread-safe initialization
-        if (_config is null)
+        if (_current is null)
         {
             lock (_configureLock)
             {
-                if (_config is null)
+                if (_current is null)
                 {
-                    var builder = new StateMachineConfigurationBuilder<TEntity, TEnum>(statusPropertyAccessor);
-                    configureAction(builder);
-                    _config = builder.Build(); // Build validates required settings like initial state
+                    _current = StateMachineDefinition<TEntity, TEnum>.Build(statusPropertyAccessor, configureAction);
 
                     return; // Exit after successful configuration
                 }
@@ -68,21 +85,51 @@ public static partial class StateMachine<TEntity, TEnum>
     }
 
     /// <summary>
-    /// Gets the configured state machine details. Internal use primarily.
+    /// Registers a pre-built state machine instance as the singleton for this TEntity/TEnum combination.
+    /// Like <see cref="Configure"/>, this is write-once.
     /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown if the state machine is not configured.</exception>
-    private static StateMachineConfiguration<TEntity, TEnum> GetConfiguration()
+    /// <param name="definition">The instance to register.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="definition"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the state machine for this TEntity/TEnum is already configured.</exception>
+    public static void Use(StateMachineDefinition<TEntity, TEnum> definition)
     {
-        if (_config is null)
-            throw new InvalidOperationException($"State machine for {typeof(TEntity).Name} with status {typeof(TEnum).Name} has not been configured. Call Configure() first.");
+        if (definition == null) throw new ArgumentNullException(nameof(definition));
 
-        return _config;
+        if (_current is null)
+        {
+            lock (_configureLock)
+            {
+                if (_current is null)
+                {
+                    _current = definition;
+
+                    return;
+                }
+            }
+        }
+
+        throw new InvalidOperationException($"State machine for {typeof(TEntity).Name} with status {typeof(TEnum).Name} is already configured.");
+    }
+
+    /// <summary>
+    /// Clears the registered instance for this TEntity/TEnum combination, allowing reconfiguration.
+    /// Idempotent.
+    /// </summary>
+    /// <returns>True if an instance was registered and has now been cleared; false if nothing was registered.</returns>
+    public static bool Reset()
+    {
+        lock (_configureLock)
+        {
+            var wasConfigured = _current is not null;
+            _current = null;
+            return wasConfigured;
+        }
     }
 
     /// <summary>
     /// Gets the initial state defined for this state machine.
     /// </summary>
-    public static TEnum InitialState => GetConfiguration().InitialState;
+    public static TEnum InitialState => Current.InitialState;
 
     /// <summary>
     /// Checks if a transition from the entity's current state to the specified target state is possible,
@@ -91,12 +138,7 @@ public static partial class StateMachine<TEntity, TEnum>
     /// <param name="entity">The entity instance.</param>
     /// <param name="toState">The target state.</param>
     /// <returns>True if the transition is allowed, false otherwise.</returns>
-    public static bool CanTransition(TEntity entity, TEnum toState)
-    {
-        var config = GetConfiguration();
-        var currentState = config.GetCurrentState(entity);
-        return CanTransition(entity, currentState, toState);
-    }
+    public static bool CanTransition(TEntity entity, TEnum toState) => Current.CanTransition(entity, toState);
 
     /// <summary>
     /// Checks if a transition from the specified source state to the target state is possible
@@ -106,18 +148,7 @@ public static partial class StateMachine<TEntity, TEnum>
     /// <param name="fromState">The source state.</param>
     /// <param name="toState">The target state.</param>
     /// <returns>True if the transition is allowed, false otherwise.</returns>
-    public static bool CanTransition(TEntity entity, TEnum fromState, TEnum toState)
-    {
-        var config = GetConfiguration();
-        var transition = config.FindTransition(fromState, toState);
-
-        if (transition == null)
-        {
-            return false; // No transition defined
-        }
-
-        return transition.IsPreConditionMet(entity); // Check pre-condition
-    }
+    public static bool CanTransition(TEntity entity, TEnum fromState, TEnum toState) => Current.CanTransition(entity, fromState, toState);
 
     /// <summary>
     /// Attempts to transition the entity to the specified target state from its current state.
@@ -128,10 +159,7 @@ public static partial class StateMachine<TEntity, TEnum>
     /// <param name="toState">The target state.</param>
     /// <returns>True if the transition was successful, false otherwise.</returns>
     /// <exception cref="StateMachineException">Can be thrown by PostActions if they encounter errors.</exception>
-    public static bool TryTransition(TEntity entity, TEnum toState)
-    {
-        return TryTransition(entity, toState, reason: null, metadata: null);
-    }
+    public static bool TryTransition(TEntity entity, TEnum toState) => Current.TryTransition(entity, toState);
 
     /// <summary>
     /// Attempts to transition the entity to the specified target state from its current state,
@@ -142,64 +170,7 @@ public static partial class StateMachine<TEntity, TEnum>
     /// <param name="reason">Optional reason or description for the transition.</param>
     /// <param name="metadata">Optional metadata associated with the transition.</param>
     /// <returns>True if the transition was successful, false otherwise.</returns>
-    public static bool TryTransition(TEntity entity, TEnum toState, string? reason, IReadOnlyDictionary<string, object>? metadata = null)
-    {
-        var config = GetConfiguration();
-        var currentState = config.GetCurrentState(entity);
-        return TryTransitionInternal(config, entity, currentState, toState, reason, metadata, force: false);
-    }
-
-    private static bool TryTransitionInternal(
-        StateMachineConfiguration<TEntity, TEnum> config,
-        TEntity entity,
-        TEnum currentState,
-        TEnum toState,
-        string? reason,
-        IReadOnlyDictionary<string, object>? metadata,
-        bool force)
-    {
-        var transition = config.FindTransition(currentState, toState);
-
-        if (transition == null)
-        {
-            return false; // Transition not defined
-        }
-
-        if (!force && !transition.IsPreConditionMet(entity))
-        {
-            return false; // Pre-condition failed (unless forced)
-        }
-
-        try
-        {
-            // 1. Execute transition's post-action (legacy - runs before state change)
-            transition.ExecutePostAction(entity);
-
-            // 2. Execute OnExit action for current state
-            config.ExecuteOnExit(entity, currentState);
-
-            // 3. Update the entity's state property
-            config.SetState(entity, toState);
-
-            // 4. Execute OnEntry action for new state
-            config.ExecuteOnEntry(entity, toState);
-
-            // 5. Raise OnTransition event
-            var context = new TransitionContext<TEntity, TEnum>(entity, currentState, toState, reason, metadata, force);
-            OnTransition?.Invoke(context);
-
-            return true;
-        }
-        catch (Exception ex)
-        {
-            throw new StateMachineException($"Error during transition from {currentState} to {toState}: {ex.Message}", ex);
-        }
-    }
-
-    private static bool TryTransition(StateMachineConfiguration<TEntity, TEnum> config, TEntity entity, TEnum currentState, TEnum toState)
-    {
-        return TryTransitionInternal(config, entity, currentState, toState, reason: null, metadata: null, force: false);
-    }
+    public static bool TryTransition(TEntity entity, TEnum toState, string? reason, IReadOnlyDictionary<string, object>? metadata = null) => Current.TryTransition(entity, toState, reason, metadata);
 
     /// <summary>
     /// Attempts to transition the entity to the first valid target state from its current state,
@@ -209,23 +180,7 @@ public static partial class StateMachine<TEntity, TEnum>
     /// <param name="toStates">The ordered list of possible target states to try.</param>
     /// <param name="successfulState">The state to which the transition was made, or default if none succeeded.</param>
     /// <returns>True if a transition was successful, false otherwise.</returns>
-    public static bool TryTransitionAny(TEntity entity, IReadOnlyCollection<TEnum> toStates, out TEnum successfulState)
-    {
-        var config = GetConfiguration();
-        var currentState = config.GetCurrentState(entity);
-
-        foreach (var toState in toStates)
-        {
-            if (TryTransition(config, entity, currentState, toState))
-            {
-                successfulState = toState;
-                return true;
-            }
-        }
-
-        successfulState = default;
-        return false;
-    }
+    public static bool TryTransitionAny(TEntity entity, IReadOnlyCollection<TEnum> toStates, out TEnum successfulState) => Current.TryTransitionAny(entity, toStates, out successfulState);
 
     /// <summary>
     /// Attempts to transition the entity to the first valid target state from its current state.
@@ -233,13 +188,7 @@ public static partial class StateMachine<TEntity, TEnum>
     /// </summary>
     /// <param name="entity">The entity instance.</param>
     /// <returns>True if a transition was successful, false otherwise.</returns>
-    public static bool TryTransitionAny(TEntity entity)
-    {
-        var config = GetConfiguration();
-        var currentState = config.GetCurrentState(entity);
-
-        return config.GetTransitionsFrom(currentState).Any(transition => TryTransition(config, entity, currentState, transition.ToState));
-    }
+    public static bool TryTransitionAny(TEntity entity) => Current.TryTransitionAny(entity);
 
     /// <summary>
     /// Gets a list of states that the entity can transition to from its current state,
@@ -247,15 +196,7 @@ public static partial class StateMachine<TEntity, TEnum>
     /// </summary>
     /// <param name="entity">The entity instance.</param>
     /// <returns>An enumerable of possible target states.</returns>
-    public static IEnumerable<TEnum> GetPossibleTransitions(TEntity entity)
-    {
-        var config = GetConfiguration();
-        var currentState = config.GetCurrentState(entity);
-
-        return config.GetTransitionsFrom(currentState)
-            .Where(transition => transition.IsPreConditionMet(entity))
-            .Select(transition => transition.ToState);
-    }
+    public static IEnumerable<TEnum> GetPossibleTransitions(TEntity entity) => Current.GetPossibleTransitions(entity);
 
     /// <summary>
     /// Gets a list of all defined target states reachable from a given state,
@@ -263,31 +204,17 @@ public static partial class StateMachine<TEntity, TEnum>
     /// </summary>
     /// <param name="fromState">The source state.</param>
     /// <returns>An enumerable of defined target states.</returns>
-    public static IEnumerable<TEnum> GetDefinedTransitions(TEnum fromState)
-    {
-        var config = GetConfiguration();
-        return config.GetTransitionsFrom(fromState)
-            .Select(transition => transition.ToState);
-    }
+    public static IEnumerable<TEnum> GetDefinedTransitions(TEnum fromState) => Current.GetDefinedTransitions(fromState);
 
     /// <summary>
     /// Returns true if the given state is a final state (i.e., has no outgoing transitions).
     /// </summary>
-    public static bool IsFinalState(TEnum state)
-    {
-        var config = GetConfiguration();
-        return config.FinalStates.Contains(state);
-    }
+    public static bool IsFinalState(TEnum state) => Current.IsFinalState(state);
 
     /// <summary>
     /// Returns true if the entity is currently in a final state (i.e., has no outgoing transitions).
     /// </summary>
-    public static bool IsInFinalState(TEntity entity)
-    {
-        var config = GetConfiguration();
-        var currentState = config.GetCurrentState(entity);
-        return config.FinalStates.Contains(currentState);
-    }
+    public static bool IsInFinalState(TEntity entity) => Current.IsInFinalState(entity);
 
     /// <summary>
     /// Forces a transition to the specified state, bypassing pre-conditions.
@@ -299,46 +226,25 @@ public static partial class StateMachine<TEntity, TEnum>
     /// <param name="reason">Optional reason for the forced transition.</param>
     /// <param name="metadata">Optional metadata associated with the transition.</param>
     /// <returns>True if the transition was successful (transition was defined), false otherwise.</returns>
-    public static bool ForceTransition(TEntity entity, TEnum toState, string? reason = null, IReadOnlyDictionary<string, object>? metadata = null)
-    {
-        var config = GetConfiguration();
-        var currentState = config.GetCurrentState(entity);
-        return TryTransitionInternal(config, entity, currentState, toState, reason, metadata, force: true);
-    }
+    public static bool ForceTransition(TEntity entity, TEnum toState, string? reason = null, IReadOnlyDictionary<string, object>? metadata = null) => Current.ForceTransition(entity, toState, reason, metadata);
 
     /// <summary>
     /// Gets all states defined in the enum type.
     /// </summary>
     /// <returns>An array of all enum values.</returns>
-    public static TEnum[] GetAllStates()
-    {
-#if NET9_0_OR_GREATER
-        return Enum.GetValues<TEnum>();
-#else
-        return Enum.GetValues(typeof(TEnum)).Cast<TEnum>().ToArray();
-#endif
-    }
+    public static TEnum[] GetAllStates() => Current.GetAllStates();
 
     /// <summary>
     /// Gets all defined transitions in the state machine.
     /// </summary>
     /// <returns>A dictionary where keys are source states and values are arrays of target states.</returns>
-    public static IReadOnlyDictionary<TEnum, TEnum[]> GetAllTransitions()
-    {
-        var config = GetConfiguration();
-        return config.Transitions.ToDictionary(
-            kvp => kvp.Key,
-            kvp => kvp.Value.Select(t => t.ToState).ToArray());
-    }
+    public static IReadOnlyDictionary<TEnum, TEnum[]> GetAllTransitions() => Current.GetAllTransitions();
 
     /// <summary>
     /// Generates a Mermaid graph definition string representing the configured state machine.
     /// </summary>
     /// <returns>A string suitable for rendering with Mermaid.js (e.g., in Markdown).</returns>
-    public static string GenerateMermaidGraph()
-    {
-        return GenerateMermaidGraph(entity: default, currentState: null);
-    }
+    public static string GenerateMermaidGraph() => Current.GenerateMermaidGraph();
 
     /// <summary>
     /// Generates a Mermaid graph definition string representing the configured state machine
@@ -346,10 +252,7 @@ public static partial class StateMachine<TEntity, TEnum>
     /// </summary>
     /// <param name="entity">The entity instance whose current state should be highlighted.</param>
     /// <returns>A string suitable for rendering with Mermaid.js.</returns>
-    public static string GenerateMermaidGraph(TEntity entity)
-    {
-        return GenerateMermaidGraph(entity: entity, null);
-    }
+    public static string GenerateMermaidGraph(TEntity entity) => Current.GenerateMermaidGraph(entity);
 
     /// <summary>
     /// Generates a Mermaid graph definition string representing the configured state machine
@@ -357,80 +260,5 @@ public static partial class StateMachine<TEntity, TEnum>
     /// </summary>
     /// <param name="currentState">The state to highlight.</param>
     /// <returns>A string suitable for rendering with Mermaid.js.</returns>
-    public static string GenerateMermaidGraph(TEnum currentState)
-    {
-        return GenerateMermaidGraph(entity: default, currentState);
-    }
-
-    private static string GenerateMermaidGraph(TEntity? entity, TEnum? currentState)
-    {
-        var config = GetConfiguration();
-        var sb = new StringBuilder();
-
-        // If entity is provided but currentState is default, get the current state from the entity
-        if (entity is not null && currentState is null)
-            currentState = config.GetCurrentState(entity);
-
-        sb.AppendLine("graph TD"); // Top-Down graph
-
-        // Add style for current state if specified
-        if (currentState is not null)
-        {
-            sb.AppendLine("    %% Styling for current state");
-            sb.AppendLine($"    style {currentState} fill:#ffffaa,stroke:#ffaa00,stroke-width:3px");
-        }
-
-        // Add initial state marker
-        sb.AppendLine($"    Start((\u26aa)) --> {config.InitialState}");
-
-        // Add all defined transitions
-        var allTransitions = config.Transitions.Values.SelectMany(list => list).ToArray();
-
-        if (!allTransitions.Any())
-        {
-            // If only initial state defined, ensure it shows up
-            sb.AppendLine($"    {config.InitialState}");
-        }
-        else
-        {
-            foreach (var transition in allTransitions)
-            {
-                if (!string.IsNullOrWhiteSpace(transition.PreConditionExpression))
-                {
-                    // Escape quotes in the condition expression for the label
-                    var safeCondition = transition.PreConditionExpression.Replace("\"", "#quot;");
-                    sb.AppendLine($"    {transition.FromState} -- \"{safeCondition}\" --> {transition.ToState}");
-                }
-                else
-                {
-                    sb.AppendLine($"    {transition.FromState} --> {transition.ToState}");
-                }
-            }
-        }
-
-        // Optional: Add states that might only be initial or final states and have no explicit transitions listed
-        //var allStatesMentioned = new HashSet<TEnum>(config.Transitions.Keys);
-        //allStatesMentioned.UnionWith(allTransitions.Select(t => t.ToState));
-        //allStatesMentioned.Add(config.InitialState);
-
-        // This part is usually implicitly handled by Mermaid, but can be explicit if needed
-        // foreach(var state in allStatesMentioned) {
-        //     if (!allTransitions.Any(t => t.FromState.Equals(state) || t.ToState.Equals(state))) {
-        //         sb.AppendLine($"    {state}"); // Ensure lone states are declared
-        //     }
-        // }
-
-        return sb.ToString();
-    }
-
-    /// <summary>
-    /// Clears the configuration for this specific StateMachine&lt;TEntity, TEnum>.
-    /// Primarily useful for testing purposes to allow reconfiguration.
-    /// Use with caution in production environments.
-    /// </summary>
-    internal static void ClearConfiguration_TestOnly()
-    {
-        _config = null; // Reset the configuration
-        OnTransition = null; // Clear event handlers
-    }
+    public static string GenerateMermaidGraph(TEnum currentState) => Current.GenerateMermaidGraph(currentState);
 }

--- a/SlimStateMachine/StateMachineDefinition.D2.cs
+++ b/SlimStateMachine/StateMachineDefinition.D2.cs
@@ -1,0 +1,178 @@
+using System.Text;
+
+namespace SlimStateMachine;
+
+public sealed partial class StateMachineDefinition<TEntity, TEnum>
+    where TEnum : struct, Enum
+{
+    /// <summary>
+    /// Generates a D2 diagram definition string representing the configured state machine.
+    /// </summary>
+    /// <param name="includeStyles">When true, includes styling for the diagram. Default is true.</param>
+    /// <returns>A string suitable for rendering with D2.</returns>
+    public string GenerateD2Graph(bool includeStyles = true)
+    {
+        return GenerateD2Graph(entity: default, currentState: null, includeStyles);
+    }
+
+    /// <summary>
+    /// Generates a D2 diagram definition string representing the configured state machine
+    /// with the current state highlighted.
+    /// </summary>
+    /// <param name="entity">The entity instance whose current state should be highlighted.</param>
+    /// <param name="includeStyles">When true, includes styling for the diagram. Default is true.</param>
+    /// <returns>A string suitable for rendering with D2.</returns>
+    public string GenerateD2Graph(TEntity entity, bool includeStyles = true)
+    {
+        return GenerateD2Graph(entity: entity, null, includeStyles);
+    }
+
+    /// <summary>
+    /// Generates a D2 diagram definition string representing the configured state machine
+    /// with the specified state highlighted.
+    /// </summary>
+    /// <param name="currentState">The state to highlight.</param>
+    /// <param name="includeStyles">When true, includes styling for the diagram. Default is true.</param>
+    /// <returns>A string suitable for rendering with D2.</returns>
+    public string GenerateD2Graph(TEnum currentState, bool includeStyles = true)
+    {
+        return GenerateD2Graph(entity: default, currentState, includeStyles);
+    }
+
+    private string GenerateD2Graph(TEntity? entity, TEnum? currentState, bool includeStyles)
+    {
+        var config = _config;
+        var sb = new StringBuilder();
+
+        // If entity is provided but currentState is default, get the current state from the entity
+        if (entity is not null && currentState is null)
+            currentState = config.GetCurrentState(entity);
+
+        // Track if we're highlighting a specific state
+        var isHighlightingState = currentState is not null;
+
+        // Add title and direction
+        sb.AppendLine($"# State Machine: {typeof(TEntity).Name} - {typeof(TEnum).Name}");
+        if (isHighlightingState)
+            sb.AppendLine($"# Current State: {currentState}");
+        sb.AppendLine("direction: down");
+        sb.AppendLine();
+
+        // Add styling if requested
+        if (includeStyles)
+        {
+            sb.AppendLine("# Styles");
+            sb.AppendLine("style {");
+            sb.AppendLine("  fill: honeydew");
+            sb.AppendLine("  stroke: limegreen");
+            sb.AppendLine("  stroke-width: 2");
+            sb.AppendLine("  font-size: 14");
+            sb.AppendLine("  shadow: true");
+            sb.AppendLine("}");
+            sb.AppendLine();
+
+            // Style for the Start node
+            sb.AppendLine("Start: {");
+            sb.AppendLine("  shape: circle");
+            sb.AppendLine("  style.fill: lightgreen");
+            sb.AppendLine("  style.stroke: green");
+            sb.AppendLine("  width: 40");
+            sb.AppendLine("  height: 40");
+            sb.AppendLine("}");
+            sb.AppendLine();
+
+            // Add highlighting style for current state if specified
+            if (isHighlightingState)
+            {
+                sb.AppendLine($"{currentState}: {{");
+                sb.AppendLine("  style.fill: lightyellow");
+                sb.AppendLine("  style.stroke: orange");
+                sb.AppendLine("  style.stroke-width: 3");
+                sb.AppendLine("  style.shadow: true");
+                sb.AppendLine("}");
+                sb.AppendLine();
+            }
+        }
+
+        // Add initial state marker
+        sb.AppendLine($"Start -> {config.InitialState}");
+        sb.AppendLine();
+
+        // Add all defined transitions
+        var allTransitions = config.Transitions.Values.SelectMany(list => list).ToArray();
+
+        if (!allTransitions.Any())
+        {
+            // If only initial state defined, ensure it shows up
+            sb.AppendLine($"{config.InitialState}");
+        }
+        else
+        {
+            sb.AppendLine("# Transitions");
+            foreach (var transition in allTransitions)
+            {
+                if (!string.IsNullOrWhiteSpace(transition.PreConditionExpression))
+                {
+                    // D2 uses a different label syntax than Mermaid
+                    sb.AppendLine($"{transition.FromState} -> {transition.ToState}: {transition.PreConditionExpression}");
+                }
+                else
+                {
+                    sb.AppendLine($"{transition.FromState} -> {transition.ToState}");
+                }
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Generates a diagram definition string representing the configured state machine
+    /// in the specified format.
+    /// </summary>
+    /// <param name="diagramType">The type of diagram to generate.</param>
+    /// <returns>A string suitable for rendering with the specified diagramming tool.</returns>
+    public string GenerateDiagram(StateMachine<TEntity, TEnum>.DiagramType diagramType)
+    {
+        return diagramType switch
+        {
+            StateMachine<TEntity, TEnum>.DiagramType.Mermaid => GenerateMermaidGraph(),
+            StateMachine<TEntity, TEnum>.DiagramType.D2 => GenerateD2Graph(),
+            _ => throw new ArgumentException($"Unsupported diagram type: {diagramType}")
+        };
+    }
+
+    /// <summary>
+    /// Generates a diagram definition string representing the configured state machine
+    /// in the specified format, with the specified entity's current state highlighted.
+    /// </summary>
+    /// <param name="diagramType">The type of diagram to generate.</param>
+    /// <param name="entity">The entity whose current state should be highlighted.</param>
+    /// <returns>A string suitable for rendering with the specified diagramming tool.</returns>
+    public string GenerateDiagram(StateMachine<TEntity, TEnum>.DiagramType diagramType, TEntity entity)
+    {
+        return diagramType switch
+        {
+            StateMachine<TEntity, TEnum>.DiagramType.Mermaid => GenerateMermaidGraph(entity),
+            StateMachine<TEntity, TEnum>.DiagramType.D2 => GenerateD2Graph(entity),
+            _ => throw new ArgumentException($"Unsupported diagram type: {diagramType}")
+        };
+    }
+
+    /// <summary>
+    /// Generates a diagram definition string representing the configured state machine
+    /// in the specified format, with the specified state highlighted.
+    /// </summary>
+    /// <param name="diagramType">The type of diagram to generate.</param>
+    /// <param name="currentState">The state to highlight.</param>
+    /// <returns>A string suitable for rendering with the specified diagramming tool.</returns>
+    public string GenerateDiagram(StateMachine<TEntity, TEnum>.DiagramType diagramType, TEnum currentState)
+    {
+        return diagramType switch
+        {
+            StateMachine<TEntity, TEnum>.DiagramType.Mermaid => GenerateMermaidGraph(currentState),
+            StateMachine<TEntity, TEnum>.DiagramType.D2 => GenerateD2Graph(currentState),
+            _ => throw new ArgumentException($"Unsupported diagram type: {diagramType}")
+        };
+    }
+}

--- a/SlimStateMachine/StateMachineDefinition.cs
+++ b/SlimStateMachine/StateMachineDefinition.cs
@@ -1,0 +1,367 @@
+using System.Linq.Expressions;
+using System.Text;
+using SlimStateMachine.Internal;
+
+namespace SlimStateMachine;
+
+/// <summary>
+/// An owned, self-contained state machine instance for a given entity type and its status enum property.
+/// Holds its compiled configuration and the transition engine; callers create one via <see cref="Build"/>
+/// and discard it normally (teardown is garbage collection).
+/// </summary>
+/// <typeparam name="TEntity">The type of the entity being managed.</typeparam>
+/// <typeparam name="TEnum">The enum type representing the state (must be struct, Enum).</typeparam>
+public sealed partial class StateMachineDefinition<TEntity, TEnum>
+    where TEnum : struct, Enum
+{
+    private readonly StateMachineConfiguration<TEntity, TEnum> _config;
+
+    private StateMachineDefinition(StateMachineConfiguration<TEntity, TEnum> config)
+    {
+        _config = config;
+    }
+
+    /// <summary>
+    /// Builds a new state machine instance for the given TEntity and TEnum types.
+    /// </summary>
+    /// <param name="statusPropertyAccessor">An expression identifying the status property (e.g., `invoice => invoice.Status`).</param>
+    /// <param name="configureAction">An action that uses the builder to define states and transitions.</param>
+    /// <exception cref="ArgumentNullException">Thrown if parameters are null.</exception>
+    /// <exception cref="StateMachineException">Thrown if configuration is invalid (e.g., missing initial state).</exception>
+    public static StateMachineDefinition<TEntity, TEnum> Build(
+        Expression<Func<TEntity, TEnum>> statusPropertyAccessor,
+        Action<StateMachineConfigurationBuilder<TEntity, TEnum>> configureAction)
+    {
+        if (statusPropertyAccessor == null) throw new ArgumentNullException(nameof(statusPropertyAccessor));
+        if (configureAction == null) throw new ArgumentNullException(nameof(configureAction));
+
+        var builder = new StateMachineConfigurationBuilder<TEntity, TEnum>(statusPropertyAccessor);
+        configureAction(builder);
+        return new StateMachineDefinition<TEntity, TEnum>(builder.Build()); // Build validates required settings like initial state
+    }
+
+    /// <summary>
+    /// Event raised after a successful state transition.
+    /// </summary>
+    public event Action<TransitionContext<TEntity, TEnum>>? OnTransition;
+
+    /// <summary>
+    /// Gets the initial state defined for this state machine.
+    /// </summary>
+    public TEnum InitialState => _config.InitialState;
+
+    /// <summary>
+    /// Checks if a transition from the entity's current state to the specified target state is possible,
+    /// considering any defined pre-conditions.
+    /// </summary>
+    /// <param name="entity">The entity instance.</param>
+    /// <param name="toState">The target state.</param>
+    /// <returns>True if the transition is allowed, false otherwise.</returns>
+    public bool CanTransition(TEntity entity, TEnum toState)
+    {
+        var currentState = _config.GetCurrentState(entity);
+        return CanTransition(entity, currentState, toState);
+    }
+
+    /// <summary>
+    /// Checks if a transition from the specified source state to the target state is possible
+    /// for the given entity, considering any defined pre-conditions.
+    /// </summary>
+    /// <param name="entity">The entity instance.</param>
+    /// <param name="fromState">The source state.</param>
+    /// <param name="toState">The target state.</param>
+    /// <returns>True if the transition is allowed, false otherwise.</returns>
+    public bool CanTransition(TEntity entity, TEnum fromState, TEnum toState)
+    {
+        var transition = _config.FindTransition(fromState, toState);
+
+        if (transition == null)
+        {
+            return false; // No transition defined
+        }
+
+        return transition.IsPreConditionMet(entity); // Check pre-condition
+    }
+
+    /// <summary>
+    /// Attempts to transition the entity to the specified target state from its current state.
+    /// If the transition is allowed (passes pre-conditions), the entity's state property is updated,
+    /// and any post-transition action is executed.
+    /// </summary>
+    /// <param name="entity">The entity instance.</param>
+    /// <param name="toState">The target state.</param>
+    /// <returns>True if the transition was successful, false otherwise.</returns>
+    /// <exception cref="StateMachineException">Can be thrown by PostActions if they encounter errors.</exception>
+    public bool TryTransition(TEntity entity, TEnum toState)
+    {
+        return TryTransition(entity, toState, reason: null, metadata: null);
+    }
+
+    /// <summary>
+    /// Attempts to transition the entity to the specified target state from its current state,
+    /// with an optional reason for the transition.
+    /// </summary>
+    /// <param name="entity">The entity instance.</param>
+    /// <param name="toState">The target state.</param>
+    /// <param name="reason">Optional reason or description for the transition.</param>
+    /// <param name="metadata">Optional metadata associated with the transition.</param>
+    /// <returns>True if the transition was successful, false otherwise.</returns>
+    public bool TryTransition(TEntity entity, TEnum toState, string? reason, IReadOnlyDictionary<string, object>? metadata = null)
+    {
+        var currentState = _config.GetCurrentState(entity);
+        return TryTransitionInternal(entity, currentState, toState, reason, metadata, force: false);
+    }
+
+    private bool TryTransitionInternal(
+        TEntity entity,
+        TEnum currentState,
+        TEnum toState,
+        string? reason,
+        IReadOnlyDictionary<string, object>? metadata,
+        bool force)
+    {
+        var transition = _config.FindTransition(currentState, toState);
+
+        if (transition == null)
+        {
+            return false; // Transition not defined
+        }
+
+        if (!force && !transition.IsPreConditionMet(entity))
+        {
+            return false; // Pre-condition failed (unless forced)
+        }
+
+        try
+        {
+            // 1. Execute transition's post-action (legacy - runs before state change)
+            transition.ExecutePostAction(entity);
+
+            // 2. Execute OnExit action for current state
+            _config.ExecuteOnExit(entity, currentState);
+
+            // 3. Update the entity's state property
+            _config.SetState(entity, toState);
+
+            // 4. Execute OnEntry action for new state
+            _config.ExecuteOnEntry(entity, toState);
+
+            // 5. Raise OnTransition event
+            var context = new TransitionContext<TEntity, TEnum>(entity, currentState, toState, reason, metadata, force);
+            OnTransition?.Invoke(context);
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            throw new StateMachineException($"Error during transition from {currentState} to {toState}: {ex.Message}", ex);
+        }
+    }
+
+    private bool TryTransition(TEntity entity, TEnum currentState, TEnum toState)
+    {
+        return TryTransitionInternal(entity, currentState, toState, reason: null, metadata: null, force: false);
+    }
+
+    /// <summary>
+    /// Attempts to transition the entity to the first valid target state from its current state,
+    /// trying each of the provided possible target states in order. Returns true if any transition succeeds.
+    /// </summary>
+    /// <param name="entity">The entity instance.</param>
+    /// <param name="toStates">The ordered list of possible target states to try.</param>
+    /// <param name="successfulState">The state to which the transition was made, or default if none succeeded.</param>
+    /// <returns>True if a transition was successful, false otherwise.</returns>
+    public bool TryTransitionAny(TEntity entity, IReadOnlyCollection<TEnum> toStates, out TEnum successfulState)
+    {
+        var currentState = _config.GetCurrentState(entity);
+
+        foreach (var toState in toStates)
+        {
+            if (TryTransition(entity, currentState, toState))
+            {
+                successfulState = toState;
+                return true;
+            }
+        }
+
+        successfulState = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to transition the entity to the first valid target state from its current state.
+    /// Returns true if any transition succeeds.
+    /// </summary>
+    /// <param name="entity">The entity instance.</param>
+    /// <returns>True if a transition was successful, false otherwise.</returns>
+    public bool TryTransitionAny(TEntity entity)
+    {
+        var currentState = _config.GetCurrentState(entity);
+
+        return _config.GetTransitionsFrom(currentState).Any(transition => TryTransition(entity, currentState, transition.ToState));
+    }
+
+    /// <summary>
+    /// Gets a list of states that the entity can transition to from its current state,
+    /// considering pre-conditions.
+    /// </summary>
+    /// <param name="entity">The entity instance.</param>
+    /// <returns>An enumerable of possible target states.</returns>
+    public IEnumerable<TEnum> GetPossibleTransitions(TEntity entity)
+    {
+        var currentState = _config.GetCurrentState(entity);
+
+        return _config.GetTransitionsFrom(currentState)
+            .Where(transition => transition.IsPreConditionMet(entity))
+            .Select(transition => transition.ToState);
+    }
+
+    /// <summary>
+    /// Gets a list of all defined target states reachable from a given state,
+    /// *without* considering pre-conditions based on a specific entity instance.
+    /// </summary>
+    /// <param name="fromState">The source state.</param>
+    /// <returns>An enumerable of defined target states.</returns>
+    public IEnumerable<TEnum> GetDefinedTransitions(TEnum fromState)
+    {
+        return _config.GetTransitionsFrom(fromState)
+            .Select(transition => transition.ToState);
+    }
+
+    /// <summary>
+    /// Returns true if the given state is a final state (i.e., has no outgoing transitions).
+    /// </summary>
+    public bool IsFinalState(TEnum state)
+    {
+        return _config.FinalStates.Contains(state);
+    }
+
+    /// <summary>
+    /// Returns true if the entity is currently in a final state (i.e., has no outgoing transitions).
+    /// </summary>
+    public bool IsInFinalState(TEntity entity)
+    {
+        var currentState = _config.GetCurrentState(entity);
+        return _config.FinalStates.Contains(currentState);
+    }
+
+    /// <summary>
+    /// Forces a transition to the specified state, bypassing pre-conditions.
+    /// The transition must still be defined in the state machine configuration.
+    /// Use with caution - this is intended for administrative or recovery scenarios.
+    /// </summary>
+    /// <param name="entity">The entity instance.</param>
+    /// <param name="toState">The target state.</param>
+    /// <param name="reason">Optional reason for the forced transition.</param>
+    /// <param name="metadata">Optional metadata associated with the transition.</param>
+    /// <returns>True if the transition was successful (transition was defined), false otherwise.</returns>
+    public bool ForceTransition(TEntity entity, TEnum toState, string? reason = null, IReadOnlyDictionary<string, object>? metadata = null)
+    {
+        var currentState = _config.GetCurrentState(entity);
+        return TryTransitionInternal(entity, currentState, toState, reason, metadata, force: true);
+    }
+
+    /// <summary>
+    /// Gets all states defined in the enum type.
+    /// </summary>
+    /// <returns>An array of all enum values.</returns>
+    public TEnum[] GetAllStates()
+    {
+#if NET9_0_OR_GREATER
+        return Enum.GetValues<TEnum>();
+#else
+        return Enum.GetValues(typeof(TEnum)).Cast<TEnum>().ToArray();
+#endif
+    }
+
+    /// <summary>
+    /// Gets all defined transitions in the state machine.
+    /// </summary>
+    /// <returns>A dictionary where keys are source states and values are arrays of target states.</returns>
+    public IReadOnlyDictionary<TEnum, TEnum[]> GetAllTransitions()
+    {
+        return _config.Transitions.ToDictionary(
+            kvp => kvp.Key,
+            kvp => kvp.Value.Select(t => t.ToState).ToArray());
+    }
+
+    /// <summary>
+    /// Generates a Mermaid graph definition string representing the configured state machine.
+    /// </summary>
+    /// <returns>A string suitable for rendering with Mermaid.js (e.g., in Markdown).</returns>
+    public string GenerateMermaidGraph()
+    {
+        return GenerateMermaidGraph(entity: default, currentState: null);
+    }
+
+    /// <summary>
+    /// Generates a Mermaid graph definition string representing the configured state machine
+    /// with the current state of the provided entity highlighted.
+    /// </summary>
+    /// <param name="entity">The entity instance whose current state should be highlighted.</param>
+    /// <returns>A string suitable for rendering with Mermaid.js.</returns>
+    public string GenerateMermaidGraph(TEntity entity)
+    {
+        return GenerateMermaidGraph(entity: entity, null);
+    }
+
+    /// <summary>
+    /// Generates a Mermaid graph definition string representing the configured state machine
+    /// with the specified state highlighted.
+    /// </summary>
+    /// <param name="currentState">The state to highlight.</param>
+    /// <returns>A string suitable for rendering with Mermaid.js.</returns>
+    public string GenerateMermaidGraph(TEnum currentState)
+    {
+        return GenerateMermaidGraph(entity: default, currentState);
+    }
+
+    private string GenerateMermaidGraph(TEntity? entity, TEnum? currentState)
+    {
+        var config = _config;
+        var sb = new StringBuilder();
+
+        // If entity is provided but currentState is default, get the current state from the entity
+        if (entity is not null && currentState is null)
+            currentState = config.GetCurrentState(entity);
+
+        sb.AppendLine("graph TD"); // Top-Down graph
+
+        // Add style for current state if specified
+        if (currentState is not null)
+        {
+            sb.AppendLine("    %% Styling for current state");
+            sb.AppendLine($"    style {currentState} fill:#ffffaa,stroke:#ffaa00,stroke-width:3px");
+        }
+
+        // Add initial state marker
+        sb.AppendLine($"    Start((\u26aa)) --> {config.InitialState}");
+
+        // Add all defined transitions
+        var allTransitions = config.Transitions.Values.SelectMany(list => list).ToArray();
+
+        if (!allTransitions.Any())
+        {
+            // If only initial state defined, ensure it shows up
+            sb.AppendLine($"    {config.InitialState}");
+        }
+        else
+        {
+            foreach (var transition in allTransitions)
+            {
+                if (!string.IsNullOrWhiteSpace(transition.PreConditionExpression))
+                {
+                    // Escape quotes in the condition expression for the label
+                    var safeCondition = transition.PreConditionExpression.Replace("\"", "#quot;");
+                    sb.AppendLine($"    {transition.FromState} -- \"{safeCondition}\" --> {transition.ToState}");
+                }
+                else
+                {
+                    sb.AppendLine($"    {transition.FromState} --> {transition.ToState}");
+                }
+            }
+        }
+
+        return sb.ToString();
+    }
+}

--- a/SlimStateMachine/StateMachineDefinition.cs
+++ b/SlimStateMachine/StateMachineDefinition.cs
@@ -173,6 +173,8 @@ public sealed partial class StateMachineDefinition<TEntity, TEnum>
     /// <returns>True if a transition was successful, false otherwise.</returns>
     public bool TryTransitionAny(TEntity entity, IReadOnlyCollection<TEnum> toStates, out TEnum successfulState)
     {
+        if (toStates == null) throw new ArgumentNullException(nameof(toStates));
+
         var currentState = _config.GetCurrentState(entity);
 
         foreach (var toState in toStates)


### PR DESCRIPTION
Implements **Design C** from #9: lift the static-generic state-machine engine into an owned instance behind a thin, resettable façade.

## What changed

- **New `StateMachineDefinition<TEntity,TEnum>`** (`StateMachineDefinition.cs` + `.D2.cs`) — the real engine. Holds the compiled `StateMachineConfiguration` (frozen collections + compiled accessors, reused not duplicated), a per-instance `OnTransition` event, the full transition/query/diagram API, and the verbatim 5-step `TryTransitionInternal` order. Built via `StateMachineDefinition.Build(accessor, configure)`.
- **`StateMachine<TEntity,TEnum>` is now a façade** — `_current` + lock; `Configure`/`Use` register write-once-or-throw; new `Reset()` (idempotent `bool`); new `Current` (throws the unchanged not-configured message); static `OnTransition` forwards add/remove to `Current`. Every other member is a one-line delegation — no engine logic remains in the façade.
- **`ClearConfiguration_TestOnly()` deleted**; the existing test back-door call sites migrated to `Reset()`.

## Why

The static-generic core kept its configuration in global mutable state, which is *why* the `ClearConfiguration_TestOnly` back door had to exist. This lift removes that: tests can own an instance (parallel-safe), hold multiple configs for the same `<TEntity,TEnum>`, and rely on an instance-scoped event that dies with the instance. **No breaking change** to the published static API — existing callers recompile untouched (minor-version change).

## Quality gates

- **Build:** clean across net9.0 / net8.0 / netstandard2.0, 0 warnings.
- **Tests:** 116/116 pass (89 pre-existing + 27 new instance/façade-contract tests), stable across repeated runs.
- **Spec conformance:** 24/24 checklist items conform; zero artifacts from the rejected Design A/B alternatives.
- **Code review:** no blocking or should-fix findings.

## Approved deviations (codebase-forced)

1. `DiagramType` stays nested in `StateMachine<TEntity,TEnum>` (the instance references it qualified) so `StateMachine<…>.DiagramType` keeps compiling.
2. The 4 existing test back-door call sites were swapped to `Reset()` (required to keep the build green once the back door is deleted).
3. Static `OnTransition` forwards to `Current`, so subscribing requires `Configure`/`Use` first — all existing usage already does.

## Notes

- Out of scope by design: the Mermaid/D2 renderer-duplication cleanup, and a richer `TransitionResult`/reason-enum return type (a future additive overload).
- Under the suite's `Parallelize(ClassLevel)`, any future test class touching an already-used static `<TEntity,TEnum>` will race the existing class — an inherent property of the retained static façade; instance-based tests avoid it (the new tests use a dedicated `Ticket`/`TicketStatus` pair for façade-management cases).

Closes #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
